### PR TITLE
feat: support lazy computed&add test

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,43 +43,6 @@ const useBearStore = create(
   ));
 ```
 
-
-
-## rules
-
-computed state are calculated from top to bottom, so dependent computed state should be placed on top, otherwise the dependent computed state calculated from the last calculation will be obtained.
-
-### example
-
-`animalsCount` depends `threeBears`and`threeCats`，so `threeBears`and`threeCats` should  be above `animalsCount`。
-
-```typescript
-const useBearStore = create(
-  computed<Store, Computed>((
-    (set) => ({
-      bears: 0,
-      cats: 0,
-      addOneBear: () => set(state => ({ bears: state.bears + 1 })),
-      addOneCat: () => set(state => ({ cats: state.cats + 1 })),
-    })),
-    {
-      threeBears: (state) => {
-        console.log('threeBears recomputed');
-        return state.bears * 3 + 1
-      },
-      threeCats: (state) => {
-        console.log('threeCats recomputed');
-        return state.cats * 3
-      },
-      animalsCount: (state) => {
-        console.log('animalsCount recomputed', state);
-        return state.threeBears + state.threeCats;
-      },
-    }
-  ));
-
-```
-
 ## License 
 
 [MIT](./LICENSE)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,40 +1,53 @@
-import { memoize } from 'proxy-memoize'
-import { StateCreator } from 'zustand'
+import { memoize } from 'proxy-memoize';
+import { StateCreator } from 'zustand';
 
-type ComputeObj<T, A> = Record<keyof A, (state: T & A) => A[keyof A]>
-type Computed<T, A> = { [K in keyof A]: ReturnType<ComputeObj<T, A>[K]> }
+type ComputeObj<T, A> = {
+  [K in keyof A]: (state: T & A) => A[K];
+};
+
+function shallowClone<T extends Record<string, any>>(obj: T): T {
+  return Object.create(
+    Object.getPrototypeOf(obj),
+    Object.getOwnPropertyDescriptors(obj),
+  );
+}
 
 const computed = <T extends object, A extends object>(
-    f: StateCreator<T, [], []>,
-    compute: ComputeObj<T, A>
-): StateCreator<T & Computed<T, A>, [], []> => {
-    return (set, get, api) => {
-        type Store = ReturnType<typeof f>
-        const computedList = Object.entries(compute).map(([key, value]) => {
-            return [key, memoize(value as (state: T) => A[keyof A])] as [keyof A, (state: T) => A[keyof A]]
-        })
-        const computeAndMerge = (state: T) => {
-            return computedList.reduce(
-                (acc, [key, value]) => ({
-                    ...acc,
-                    [key]: value({ ...state, ...acc }),
-                }),
-                { ...state }
-            ) as Store & Computed<T, A>
-        }
-        const setWithComputed = (update: T | ((state: T) => T), replace?: boolean) => {
-            set((state: T) => {
-                const updated = typeof update === 'function' ? update(state) : update
-                return computeAndMerge({
-                    ...state,
-                    ...updated,
-                })
-            }, replace)
-        }
-        api.setState = setWithComputed
-        const st = f(setWithComputed, get, api)
-        return computeAndMerge(st)
-    }
-}
+  f: StateCreator<T>,
+  compute: ComputeObj<T, A>,
+): StateCreator<T & A, [], []> => {
+  return (set, get, api) => {
+    const computedState = Object.entries(compute).reduce(
+      (acc, [key, value]) => {
+        const memoizeComputeFn = memoize(value as (state: T) => A[keyof A]);
+        Object.defineProperty(acc, key, {
+          get() {
+            return memoizeComputeFn(this);
+          },
+        });
+        return acc;
+      },
+      {} as T & A,
+    );
+
+    let lastState: T & A;
+    let isChanged = true;
+    api.getState = () => {
+      if (!isChanged) {
+        return lastState;
+      }
+      lastState = Object.assign(shallowClone(computedState), get());
+      isChanged = false;
+      return lastState;
+    };
+    api.setState = (state, replace) => {
+      set(state, replace);
+      isChanged = true;
+    };
+    const st = f(api.setState, get, api);
+    return st as T & A;
+  };
+};
+
 
 export default computed

--- a/tests/computed.test.ts
+++ b/tests/computed.test.ts
@@ -1,0 +1,113 @@
+import computed from '../src';
+import { create } from 'zustand';
+
+type Store = {
+  firstName: string;
+  lastName: string;
+  age: number;
+};
+
+type ComputedStore = {
+  fullName: string;
+  nameLen: number;
+};
+
+describe('default config', () => {
+  const makeStore = () =>
+    create(
+      computed<Store, ComputedStore>(
+        () => ({
+          firstName: 'Zhang',
+          lastName: 'San',
+          age: 10,
+        }),
+        {
+          nameLen: (state) => {
+            return state.fullName.length;
+          },
+          fullName: (state) => {
+            return state.firstName + state.lastName;
+          },
+        },
+      ),
+    );
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('update state', () => {
+    const useStore = makeStore();
+    expect(useStore.getState().fullName).toEqual('ZhangSan');
+    expect(useStore.getState().nameLen).toEqual(8);
+    useStore.setState({ firstName: 'Li' });
+    useStore.setState({ lastName: 'Si' });
+    expect(useStore.getState().fullName).toEqual('LiSi');
+    expect(useStore.getState().nameLen).toEqual(4);
+  });
+
+  test('subscribe', () => {
+    const useStore = makeStore();
+    useStore.subscribe(() => {
+      expect(useStore.getState().fullName).toEqual('LiSan');
+      expect(useStore.getState().nameLen).toEqual(5);
+    });
+    useStore.setState({ firstName: 'Li' });
+  });
+});
+
+describe('lazy & memo', () => {
+  it('should be lazy', () => {
+    /**
+     * computed 在首次被访问时才会首次计算
+     */
+    const fn = jest.fn();
+    const useStore = create(
+      computed<{ count: number }, { double: number }>(
+        () => ({
+          count: 0,
+        }),
+        {
+          double: (state) => {
+            fn();
+            return state.count * 2;
+          },
+        },
+      ),
+    );
+    expect(fn).toBeCalledTimes(0);
+    const a = useStore.getState().double;
+    expect(fn).toBeCalledTimes(1);
+  });
+
+  it('should be memo', () => {
+    /**
+     * computed 在被计算后，若依赖未发生变化，不会重新计算
+     */
+    const fn = jest.fn();
+    const useStore = create(
+      computed<{ count: number }, { double: number }>(
+        () => ({
+          count: 0,
+        }),
+        {
+          double: (state) => {
+            fn();
+            return state.count * 2;
+          },
+        },
+      ),
+    );
+    expect(fn).toBeCalledTimes(0);
+    const a = useStore.getState().double;
+    expect(fn).toBeCalledTimes(1);
+    // 依赖未发生变化，不会重新计算
+    const b = useStore.getState().double;
+    expect(fn).toBeCalledTimes(1);
+    // 更新依赖
+    useStore.setState({ count: 1 });
+    // 再次访问触发重新计算
+    const c = useStore.getState().double;
+    expect(fn).toBeCalledTimes(2);
+    expect(c).toEqual(2);
+  });
+});

--- a/tests/helloWorld.test.ts
+++ b/tests/helloWorld.test.ts
@@ -1,6 +1,0 @@
-
-describe('helloWorld', () => {
-    it('returns "Hello World!"', () => {
-        expect("Hello World").toBe('Hello World')
-    })
-})


### PR DESCRIPTION
1. 增加了 lazy 计算，在 computed 首次被访问前不会计算
2. 由于有了 (1)，对 computed 的声明顺序没有了依赖
3. 增加了单测